### PR TITLE
feat: javax -> jakarta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,39 +19,11 @@
     <version>6-NEXT-SNAPSHOT</version>
   </parent>
 
-  <profiles>
-    <profile>
-      <id>java11</id>
-      <dependencies>
-        <dependency>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>com.sun.activation</groupId>
-          <artifactId>javax.activation</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>com.sun.xml.bind</groupId>
-          <artifactId>jaxb-impl</artifactId>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
-
   <dependencies>
     <dependency>
       <groupId>org.thymeleaf</groupId>
       <artifactId>thymeleaf</artifactId>
-      <version>3.0.9.RELEASE</version>
+      <version>3.1.1.RELEASE</version>
     </dependency>
 
     <dependency>
@@ -60,9 +32,8 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.5</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
 
@@ -79,6 +50,23 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.eclipse.angus</groupId>
+      <artifactId>angus-activation</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/src/main/java/nablarch/fw/web/handler/responsewriter/thymeleaf/ThymeleafResponseWriter.java
+++ b/src/main/java/nablarch/fw/web/handler/responsewriter/thymeleaf/ThymeleafResponseWriter.java
@@ -5,6 +5,8 @@ import nablarch.fw.web.handler.responsewriter.CustomResponseWriter;
 import nablarch.fw.web.servlet.ServletExecutionContext;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.WebContext;
+import org.thymeleaf.web.servlet.IServletWebExchange;
+import org.thymeleaf.web.servlet.JakartaServletWebApplication;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -47,9 +49,12 @@ public class ThymeleafResponseWriter implements CustomResponseWriter {
 
     @Override
     public void writeResponse(String pathToTemplate, ServletExecutionContext context) throws IOException {
-        WebContext webContext = new WebContext(context.getServletRequest(),
-                                               context.getServletResponse(),
-                                               context.getServletContext(),
+        JakartaServletWebApplication application
+                = JakartaServletWebApplication.buildApplication(context.getServletContext());
+        IServletWebExchange exchange
+                = application.buildExchange(context.getServletRequest(), context.getServletResponse());
+
+        WebContext webContext = new WebContext(exchange,
                                                ThreadContext.getLanguage());   // Locale
         Writer writer = context.getServletResponse().getWriter();
 

--- a/src/test/java/nablarch/fw/web/handler/responsewriter/thymeleaf/ThymeleafResponseWriterContainerManagedTest.java
+++ b/src/test/java/nablarch/fw/web/handler/responsewriter/thymeleaf/ThymeleafResponseWriterContainerManagedTest.java
@@ -13,6 +13,7 @@ import nablarch.fw.web.servlet.ServletExecutionContext;
 import nablarch.test.support.SystemRepositoryResource;
 import nablarch.test.support.web.servlet.MockServletContext;
 import nablarch.test.support.web.servlet.MockServletRequest;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -21,18 +22,27 @@ import static org.junit.Assert.assertThat;
 
 public class ThymeleafResponseWriterContainerManagedTest {
 
-    /** モックの{@link javax.servlet.ServletRequest} */
+    /** モックの{@link jakarta.servlet.ServletContext}  */
+    private final MockServletContext mockServletContext = new MockServletContext();
+
+    /** モックの{@link jakarta.servlet.ServletRequest} */
     private final MockServletRequest mockReq = new MockServletRequest();
 
-    /** モックの{@link javax.servlet.ServletResponse} */
+    /** モックの{@link jakarta.servlet.ServletResponse} */
     private final WritableMockResponse mockRes = new WritableMockResponse();
 
     /** 実行コンテキスト */
-    private final ServletExecutionContext context = new ServletExecutionContext(mockReq, mockRes, new MockServletContext());
+    private final ServletExecutionContext context = new ServletExecutionContext(mockReq, mockRes, mockServletContext);
 
     @Rule
     public SystemRepositoryResource repo = new SystemRepositoryResource(
             "nablarch/fw/web/handler/responsewriter/thymeleaf/ThymeleafResponseWriterContainerManagedTest.xml");
+
+    @Before
+    public void setUp() {
+        mockServletContext.setContextPath("/");
+        mockReq.setServletContext(mockServletContext);
+    }
 
     /**
      * {@link SystemRepository}に登録したコンポーネントとして実行できること。

--- a/src/test/java/nablarch/fw/web/handler/responsewriter/thymeleaf/ThymeleafResponseWriterTest.java
+++ b/src/test/java/nablarch/fw/web/handler/responsewriter/thymeleaf/ThymeleafResponseWriterTest.java
@@ -24,14 +24,17 @@ public class ThymeleafResponseWriterTest {
     /** テスト対象 */
     private final ThymeleafResponseWriter sut = new ThymeleafResponseWriter();
 
-    /** モックの{@link javax.servlet.ServletRequest} */
+    /** モックの{@link jakarta.servlet.ServletContext}  */
+    private final MockServletContext mockServletContext = new MockServletContext();
+
+    /** モックの{@link jakarta.servlet.ServletRequest} */
     private final MockServletRequest mockReq = new MockServletRequest();
 
-    /** モックの{@link javax.servlet.ServletResponse} */
+    /** モックの{@link jakarta.servlet.ServletResponse} */
     private final WritableMockResponse mockRes = new WritableMockResponse();
 
     /** 実行コンテキスト */
-    private final ServletExecutionContext context = new ServletExecutionContext(mockReq, mockRes, new MockServletContext());
+    private final ServletExecutionContext context = new ServletExecutionContext(mockReq, mockRes, mockServletContext);
 
     /** 実際に出力を行う{@link TemplateEngine} */
     private final TemplateEngine engine = new TemplateEngine();// リクエストパラメータ
@@ -41,6 +44,9 @@ public class ThymeleafResponseWriterTest {
     public void setUp() {
         engine.setTemplateResolver(new ClassLoaderTemplateResolver());
         sut.setTemplateEngine(engine);
+
+        mockServletContext.setContextPath("/");
+        mockReq.setServletContext(mockServletContext);
     }
 
     /** {@link ThymeleafResponseWriter}単体で動作すること. */


### PR DESCRIPTION
モックにコンテキストパスを設定しているのは、Thymeleafの挙動が変わって内部でコンテキストパスを利用するようになったため。